### PR TITLE
test: 비동기 테스트 인프라와 기본 단위/기능 테스트 추가

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,48 +1,53 @@
-# pipenv 
-.PHONY: freeze
-freeze:
-	pipenv requirements > requirements.txt
+PYTHON ?= python
+PIPENV ?= pipenv
+DOCKER ?= docker
+DOCKER_COMPOSE ?= docker-compose
+UVICORN ?= uvicorn
+APP = app.main:app
+
+.PHONY: help freeze run test build run-docker stop-docker remove-docker build-compose up-compose down-compose upgrade downgrade
+
+help: ## 사용 가능한 명령을 보여줍니다
+	grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS=":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
+
+# pipenv
+freeze: ## Pipenv 의존성을 requirements.txt로 내보냅니다
+	$(PIPENV) requirements > requirements.txt
 
 # fastapi
-.PHONY: run
-run:
-	uvicorn app.main:app --host 0.0.0.0 --port 8002 --reload
+run: ## 개발 서버를 실행합니다
+	$(UVICORN) $(APP) --host 0.0.0.0 --port 8002 --reload
+
+# test
+test: ## 단위 및 기능 테스트를 실행합니다
+	pytest
 
 # docker
-.PHONY: build
-build:
-	docker build -t linkyboard-ai .
+build: ## Docker 이미지를 빌드합니다
+	$(DOCKER) build -t linkyboard-ai .
 
-.PHONY: run-docker
-run-docker:
-	docker run -d -p 8001:80 --name linkyboard-ai linkyboard-ai
+run-docker: ## Docker 컨테이너를 실행합니다
+	$(DOCKER) run -d -p 8001:80 --name linkyboard-ai linkyboard-ai
 
-.PHONY: stop-docker
-stop-docker:
-	docker stop linkyboard-ai
+stop-docker: ## Docker 컨테이너를 중지합니다
+	$(DOCKER) stop linkyboard-ai
 
-.PHONY: remove-docker
-remove-docker:
-	docker rm linkyboard-ai
+remove-docker: ## Docker 컨테이너를 삭제합니다
+	$(DOCKER) rm linkyboard-ai
 
 # docker-compose
-.PHONY: build-compose
-build-compose:
-	docker-compose build
+build-compose: ## docker-compose 이미지를 빌드합니다
+	$(DOCKER_COMPOSE) build
 
-.PHONY: up-compose
-up-compose:
-	docker-compose up -d
+up-compose: ## docker-compose 서비스를 시작합니다
+	$(DOCKER_COMPOSE) up -d
 
-.PHONY: down-compose
-down-compose:
-	docker-compose down	
+down-compose: ## docker-compose 서비스를 중지합니다
+	$(DOCKER_COMPOSE) down
 
 # alembic
-.PHONY: upgrade
-upgrade:
+upgrade: ## 데이터베이스를 최신 상태로 마이그레이션합니다
 	alembic upgrade head
 
-.PHONY: downgrade
-downgrade:
+downgrade: ## 데이터베이스 마이그레이션을 한 단계 되돌립니다
 	alembic downgrade -1

--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # linkyboard-ai
+
+## 테스트 실행 방법
+```bash
+make test
+```
+
+## Makefile 명령어
+```bash
+make help
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,3 +32,6 @@ tqdm==4.67.1; python_version >= '3.7'
 typing-extensions==4.14.1; python_version >= '3.9'
 typing-inspection==0.4.1; python_version >= '3.9'
 uvicorn==0.35.0; python_version >= '3.9'
+aiosqlite==0.20.0; python_version >= "3.7"
+pytest==8.3.2; python_version >= "3.8"
+pytest-asyncio==0.24.0; python_version >= "3.8"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,39 @@
+import pytest
+import pytest_asyncio
+import os, sys, pathlib
+from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker, AsyncSession
+
+os.environ.setdefault("POSTGRES_HOST", "localhost")
+os.environ.setdefault("POSTGRES_USER", "user")
+os.environ.setdefault("POSTGRES_PASSWORD", "pass")
+os.environ.setdefault("POSTGRES_DB", "test_db")
+os.environ.setdefault("OPENAI_API_KEY", "test")
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from app.core.database import Base
+
+
+@pytest_asyncio.fixture
+async def db_session(tmp_path) -> AsyncSession:
+    db_url = f"sqlite+aiosqlite:///{tmp_path}/test.db"
+    engine = create_async_engine(db_url, future=True)
+
+    # remove duplicate index definitions
+    for table in Base.metadata.tables.values():
+        seen = set()
+        for idx in list(table.indexes):
+            if idx.name in seen:
+                table.indexes.remove(idx)
+            else:
+                seen.add(idx.name)
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    async_session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with async_session() as session:
+            yield session
+    finally:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+        await engine.dispose()

--- a/tests/test_clipper_service.py
+++ b/tests/test_clipper_service.py
@@ -1,0 +1,34 @@
+import pytest
+from fastapi import BackgroundTasks
+
+from app.collect.v1.clipper.service import ClipperService
+from app.collect.v1.clipper.schemas import WebpageSyncRequest
+from app.user.user_repository import user_repository
+
+
+@pytest.mark.asyncio
+async def test_sync_webpage_creates_item_and_user(db_session):
+    service = ClipperService()
+    background_tasks = BackgroundTasks()
+    request = WebpageSyncRequest(
+        item_id=1,
+        user_id=1,
+        thumbnail="thumb",
+        title="Test Page",
+        url="http://example.com",
+        summary=None,
+        keywords=None,
+        category="test",
+        memo=None,
+        html_content="<html></html>",
+    )
+    response = await service.sync_webpage(db_session, background_tasks, request)
+    assert response.success is True
+
+    item = await service.item_repository.get_by_id(db_session, 1)
+    assert item is not None and item.title == "Test Page"
+
+    user = await user_repository.get_by_id(db_session, 1)
+    assert user is not None
+
+    assert len(background_tasks.tasks) == 1

--- a/tests/test_embedding_tasks.py
+++ b/tests/test_embedding_tasks.py
@@ -1,0 +1,50 @@
+import asyncio
+import pytest
+from fastapi import BackgroundTasks
+
+from app.collect.v1.clipper.service import ClipperService
+from app.collect.v1.clipper.schemas import WebpageSyncRequest
+
+
+@pytest.mark.asyncio
+async def test_embedding_background_task(db_session, monkeypatch):
+    service = ClipperService()
+    background_tasks = BackgroundTasks()
+    called = {"flag": False}
+
+    async def fake_create_embeddings(session, item_id, content, **kwargs):
+        called["flag"] = True
+        return []
+
+    monkeypatch.setattr(service.embedding_service, "create_embeddings", fake_create_embeddings)
+
+    class DummySessionManager:
+        async def __aenter__(self):
+            return db_session
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+
+    monkeypatch.setattr("app.collect.v1.clipper.service.AsyncSessionLocal", lambda: DummySessionManager())
+
+    request = WebpageSyncRequest(
+        item_id=1,
+        user_id=1,
+        thumbnail="thumb",
+        title="Test",
+        url="http://example.com",
+        summary=None,
+        keywords=None,
+        category="cat",
+        memo=None,
+        html_content="<html></html>",
+    )
+    await service.sync_webpage(db_session, background_tasks, request)
+
+    assert len(background_tasks.tasks) == 1
+    task = background_tasks.tasks[0]
+    if asyncio.iscoroutinefunction(task.func):
+        await task.func(*task.args, **task.kwargs)
+    else:
+        task.func(*task.args, **task.kwargs)
+
+    assert called["flag"] is True

--- a/tests/test_item_repository.py
+++ b/tests/test_item_repository.py
@@ -1,0 +1,69 @@
+import pytest
+
+from app.core.repository import item_repository
+from app.user.user_repository import user_repository
+
+
+@pytest.mark.asyncio
+async def test_create_and_get_item(db_session):
+    await user_repository.get_or_create(db_session, user_id=1)
+    item = await item_repository.create(
+        db_session,
+        id=1,
+        user_id=1,
+        item_type="webpage",
+        title="Test Item",
+        source_url="http://example.com",
+    )
+    fetched = await item_repository.get_by_id(db_session, 1)
+    assert fetched.id == item.id
+    assert fetched.title == "Test Item"
+
+
+@pytest.mark.asyncio
+async def test_search_by_title_or_description(db_session):
+    await user_repository.get_or_create(db_session, user_id=1)
+    await item_repository.create(
+        db_session,
+        id=1,
+        user_id=1,
+        item_type="webpage",
+        title="Hello World",
+        source_url="http://a.com",
+    )
+    await item_repository.create(
+        db_session,
+        id=2,
+        user_id=1,
+        item_type="webpage",
+        title="Other",
+        description="Interesting world",
+        source_url="http://b.com",
+    )
+    results = await item_repository.search_by_title_or_description(db_session, 1, "Hello")
+    assert len(results) == 1 and results[0].id == 1
+    results2 = await item_repository.search_by_title_or_description(db_session, 1, "world")
+    assert len(results2) == 2
+
+
+@pytest.mark.asyncio
+async def test_get_by_user_id(db_session):
+    await user_repository.get_or_create(db_session, user_id=2)
+    await item_repository.create(
+        db_session,
+        id=3,
+        user_id=2,
+        item_type="webpage",
+        title="First",
+        source_url="http://1.com",
+    )
+    await item_repository.create(
+        db_session,
+        id=4,
+        user_id=2,
+        item_type="webpage",
+        title="Second",
+        source_url="http://2.com",
+    )
+    items = await item_repository.get_by_user_id(db_session, user_id=2)
+    assert {item.id for item in items} == {3, 4}

--- a/tests/test_user_repository.py
+++ b/tests/test_user_repository.py
@@ -1,0 +1,22 @@
+import pytest
+
+from app.user.user_repository import user_repository
+
+
+@pytest.mark.asyncio
+async def test_get_or_create(db_session):
+    user = await user_repository.get_or_create(db_session, user_id=1)
+    assert user.id == 1
+    assert user.is_active is True
+
+
+@pytest.mark.asyncio
+async def test_activate_and_deactivate_user(db_session):
+    await user_repository.get_or_create(db_session, user_id=2)
+    await user_repository.deactivate_user(db_session, 2)
+    user = await user_repository.get_by_id(db_session, 2)
+    assert user.is_active is False
+
+    await user_repository.activate_user(db_session, 2)
+    user = await user_repository.get_by_id(db_session, 2)
+    assert user.is_active is True

--- a/tests/test_user_service.py
+++ b/tests/test_user_service.py
@@ -1,0 +1,18 @@
+import pytest
+
+from app.user.v1.service import UserService
+from app.user.v1.schemas import UserSyncRequest
+
+
+@pytest.mark.asyncio
+async def test_sync_and_get_user(db_session):
+    service = UserService()
+    request = UserSyncRequest(user_id=1, is_active=True)
+    response = await service.sync_user(db_session, request)
+    assert response.success is True
+    assert response.user_id == 1
+    assert response.created is True
+
+    user_response = await service.get_user(db_session, 1)
+    assert user_response is not None
+    assert user_response.id == 1


### PR DESCRIPTION
## Summary
- pytest 실행을 위한 `make test` 타깃과 `make help`를 추가해 Makefile을 정비했습니다
- README에 `make test`와 `make help` 사용법을 문서화했습니다

## Testing
- `pip install -r requirements.txt`
- `make test` *(mapper 초기화 오류로 실패)*

------
https://chatgpt.com/codex/tasks/task_e_68988d7023f08331bd6e460cd791b1de